### PR TITLE
Test invite flow after team fix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+---
+release type: patch
+---
+Test org invite with configured people team and git-installed plugin.


### PR DESCRIPTION
Release test after switching invite plugin team slug to `people`.\n\nIncludes a co-author trailer for @botberry so invite_contributors will attempt an invite for that user.